### PR TITLE
fix: auto-build frontend when tribal ui static assets are missing

### DIFF
--- a/lib/tribalmind/cli/ui_cmd.py
+++ b/lib/tribalmind/cli/ui_cmd.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -22,8 +22,21 @@ def _build_frontend() -> bool:
     if not _UI_SRC_DIR.exists():
         return False
 
-    pkg_manager = "pnpm" if shutil.which("pnpm") else "npm" if shutil.which("npm") else None
-    if pkg_manager is None:
+    # On Windows, node package managers are .cmd scripts that require shell=True
+    use_shell = sys.platform == "win32"
+
+    for pkg_manager in ("pnpm", "npm"):
+        try:
+            subprocess.run(
+                [pkg_manager, "--version"],
+                capture_output=True,
+                shell=use_shell,
+                check=True,
+            )
+            break
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+    else:
         return False
 
     console.print(f"[yellow]Building frontend with {pkg_manager}…[/yellow]")
@@ -33,12 +46,14 @@ def _build_frontend() -> bool:
             cwd=str(_UI_SRC_DIR),
             check=True,
             capture_output=True,
+            shell=use_shell,
         )
         subprocess.run(
             [pkg_manager, "run", "build"],
             cwd=str(_UI_SRC_DIR),
             check=True,
             capture_output=True,
+            shell=use_shell,
         )
         console.print("[green]Frontend built successfully.[/green]")
         return True


### PR DESCRIPTION
## Summary
- `tribal ui` previously showed a "Frontend not built" fallback page when static assets weren't pre-built
- Now automatically builds the React frontend using `pnpm` (or `npm`) when the static directory is missing
- Falls back to a clear error message with manual build instructions if no package manager is available or the `ui/` source doesn't exist

## Test plan
- [ ] Run `tribal ui` without pre-built static files — should auto-build and serve the dashboard
- [ ] Run `tribal ui` with pre-built static files — should serve immediately (no rebuild)
- [ ] Verify error message when neither pnpm nor npm are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)