### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Description
+
+<!-- What does this PR do? Provide a brief summary of the changes. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to any relevant issues. -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+<!-- List the key changes made in this PR. -->
+
+-
+
+## How to test
+
+<!-- Describe how reviewers can verify this change works correctly. -->
+
+1.
+
+## Checklist
+
+- [ ] I have tested these changes locally
+- [ ] I have added/updated tests where applicable
+- [ ] I have updated documentation where applicable
+- [ ] My changes do not introduce new warnings or errors


### PR DESCRIPTION
## Summary
- Adds a standardized PR template at `.github/pull_request_template.md`
- Includes sections for description, motivation, changes, testing steps, and a contributor checklist

## Test plan
- [x] Verified template file is in the correct location (`.github/pull_request_template.md`)
- [ ] Confirm template auto-populates when opening a new PR on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)