### PR TITLE
chore: update agent snippet to match improved CLAUDE.md prompt

### DIFF
--- a/lib/tribalmind/cli/agents_cmd.py
+++ b/lib/tribalmind/cli/agents_cmd.py
@@ -19,9 +19,14 @@ for shared knowledge persistence across agents and team members.
 
 ### When to recall
 
-Do NOT search memory on every task. Use `tribal recall` when appropriate:
+**IMPORTANT: When investigating issues, debugging, or answering "why does X \
+happen" questions, ALWAYS run `tribal recall` FIRST before exploring the \
+codebase or spawning exploration agents.** The answer is often already in \
+shared memory and skipping this step wastes significant time.
+
+Use `tribal recall` when:
+- You're investigating an issue or unexpected behavior (check memory FIRST)
 - You need context about the project or area you're working in
-- You hit a confusing error or unexpected behavior
 - You're stuck or unsure about the right approach
 - You need context about a past decision, convention, or known issue
 - You're working in an unfamiliar part of the codebase
@@ -35,13 +40,19 @@ tribal recall --json "<describe what you need context on>"
 As you work, **proactively** store knowledge the team would benefit from — \
 don't wait until the end of a task or for the user to ask.
 
-**Good things to remember:**
-- Non-obvious fixes, workarounds, or gotchas
-- Patterns and conventions discovered in the code
-- Important decisions and the reasoning behind them
-- How modules connect and why things are built a certain way
-- Environment or config quirks
-- Surprising behavior found during exploration or code review
+**IMPORTANT: After completing any change, immediately ask yourself: "Would \
+this knowledge help a teammate (or future me) avoid confusion or save time?" \
+If yes, run `tribal remember` right away as part of completing the task — do \
+NOT wait for the user to remind you.**
+
+**Always remember when:**
+- You change a config value and the user explains *why* (e.g. setting a flag \
+to preserve data)
+- You discover or apply a non-obvious fix, workaround, or gotcha
+- The user shares reasoning behind a decision or convention
+- You learn how modules connect or why things are built a certain way
+- You encounter environment, config, or setup quirks
+- You find surprising behavior during exploration or code review
 
 **Do NOT remember** trivial changes, obvious fixes, or things already clear \
 from the code itself.


### PR DESCRIPTION
## Description

Syncs the `TRIBAL_SNIPPET` in `agents_cmd.py` with the updated `CLAUDE.md` instructions so that `tribal setup-agents` injects the improved prompt into agent config files.

## Motivation

The CLAUDE.md prompt was improved to be more assertive about recalling memory first and remembering proactively, but the snippet injected by `tribal setup-agents` was still using the old, weaker wording.

## Changes

- Updated `TRIBAL_SNIPPET` recall section: replaced passive "Do NOT search memory on every task" with a strong directive to **always recall FIRST** before exploring or spawning agents when debugging
- Updated `TRIBAL_SNIPPET` remember section: added the "after completing any change, ask yourself..." prompt and replaced generic "Good things to remember" with specific trigger scenarios

## How to test

1. Run `tribal setup-agents --list` to verify no regressions
2. Run `tribal setup-agents -a CLAUDE.md` in a test project and verify the updated snippet is injected correctly
3. Verify existing agent files get updated cleanly with `--all`

## Checklist

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors