### PR TITLE
feat: add cross-repo recall fallback to agent snippet

### DIFF
--- a/lib/tribalmind/cli/agents_cmd.py
+++ b/lib/tribalmind/cli/agents_cmd.py
@@ -35,6 +35,15 @@ Use `tribal recall` when:
 tribal recall --json "<describe what you need context on>"
 ```
 
+**Cross-repo recall:** If a local recall returns no relevant results, or if the \
+query references a name/project/term you don't recognize in this repo, \
+**automatically retry with `--all`** to search across all repos in the account. \
+Do NOT ask the user to tell you to do this — just do it.
+
+```bash
+tribal recall --all --json "<query>"
+```
+
 ### When to remember
 
 As you work, **proactively** store knowledge the team would benefit from — \


### PR DESCRIPTION
## Description

Adds a "Cross-repo recall" instruction to the `TRIBAL_SNIPPET` in `agents_cmd.py`, so agents automatically retry with `--all` when a local `tribal recall` returns no relevant results or the query references an unrecognized project/term.

## Motivation

When an agent is asked about something from another repo (e.g. "tell me about saas-webui"), it would only search the current project's memories and report nothing found — requiring the user to manually suggest using `--all`. Agents should do this automatically.

## Changes

- Added cross-repo recall fallback paragraph and code block to `TRIBAL_SNIPPET` in `agents_cmd.py`, matching the existing `CLAUDE.md` instruction

## How to test

1. Run `tribal setup-agents -a CLAUDE.md` in a test project
2. Verify the generated `CLAUDE.md` contains the "Cross-repo recall" section with `tribal recall --all` instructions

## Checklist

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)