### PR TITLE
fix: include frontend static assets in wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dev = [
 [project.scripts]
 tribal = "tribalmind.cli.app:app"
 
+[tool.hatch.build]
+# The built React frontend is gitignored (output of `cd ui && pnpm build`)
+# but must be included in the wheel so `tribal ui` works from a pip install.
+artifacts = ["lib/tribalmind/web/static/"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["lib/tribalmind"]
 


### PR DESCRIPTION
## Description

Fixes `tribal ui` showing "Frontend not found" when installed from PyPI. The built React assets were silently excluded from the wheel because hatchling respects `.gitignore` by default, and `lib/tribalmind/web/static/` is gitignored.

## Motivation

Users installing via `pip install tribalmind[ui]` could never use `tribal ui` — the static files were missing from the package.

## Changes

- Added `artifacts = ["lib/tribalmind/web/static/"]` to `[tool.hatch.build]` in `pyproject.toml`, forcing hatchling to include the frontend build output even though it is gitignored.

## How to test

1. Build the frontend: `cd ui && pnpm install && pnpm build`
2. Build the wheel: `python -m hatchling build -t wheel`
3. Inspect the wheel: `python -c "import zipfile; z=zipfile.ZipFile('dist/tribalmind-2.0.0-py3-none-any.whl'); [print(f) for f in z.namelist() if 'static' in f]"`
4. Verify `index.html`, CSS, JS, and SVG assets are listed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)