### PR TITLE
fix: warn user when running tribal init outside a git repo

### DIFF
--- a/lib/tribalmind/cli/init_cmd.py
+++ b/lib/tribalmind/cli/init_cmd.py
@@ -151,7 +151,23 @@ def init(
         if project_root:
             root = Path(project_root).resolve()
         else:
-            root = _find_git_root() or Path.cwd()
+            git_root = _find_git_root()
+            if git_root:
+                root = git_root
+            else:
+                root = Path.cwd()
+                console.print(
+                    f"\n  [yellow]⚠  No git repository detected.[/yellow]"
+                    f"  Assistant will be named [bold]{root.name}[/bold] (directory name)."
+                )
+                from tribalmind.cli.prompts import confirm
+
+                if not confirm("  Continue?", default=True):
+                    console.print(
+                        "\n  [dim]Run[/dim] [#a78bfa]tribal init[/#a78bfa]"
+                        " [dim]from inside a git repo for repo-scoped memory.[/dim]"
+                    )
+                    raise typer.Exit()
         root_label = str(root)
         assistant_root = str(root)
 


### PR DESCRIPTION
## Description

Adds a warning and confirmation prompt when `tribal init` is run outside a git repository. Previously, the init silently fell back to using the directory name as the assistant name, which could cause confusion (e.g. a parent directory name like "Klipfolio" instead of the actual repo name "ai-pipeline").

## Motivation

Users running `tribal init` from a non-repo parent directory weren't informed that their assistant would be named after the directory rather than a specific repo. This led to memories being stored under unexpected assistant names.

## Changes

- Detect when no git repo is found and show a warning with the fallback directory name
- Prompt user for confirmation before proceeding
- If declined, show a tip to run from inside a git repo

## How to test

1. `cd` to a directory that is **not** a git repo
2. Run `tribal init`
3. Verify the warning appears with the directory name
4. Press `n` — verify the tip is shown and init exits
5. Run again and press `y` — verify init continues normally

## Checklist

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)