### PR TITLE
docs: add tribalmind.dev docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://pypi.org/project/tribalmind/"><img src="https://img.shields.io/pypi/v/tribalmind" alt="PyPI"></a>
   <a href="https://pypi.org/project/tribalmind/"><img src="https://img.shields.io/pypi/pyversions/tribalmind" alt="Python"></a>
   <a href="https://github.com/zachary-nguyen/TribalMind/blob/master/LICENSE"><img src="https://img.shields.io/github/license/zachary-nguyen/TribalMind" alt="License"></a>
+  <a href="https://tribalmind.dev/docs/getting-started"><img src="https://img.shields.io/badge/docs-tribalmind.dev-6366f1" alt="Docs"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Description

Adds a docs badge linking to tribalmind.dev/docs/getting-started in the README badge row.

## Motivation

The new documentation site at tribalmind.dev now has a full docs section. Adding a badge makes it discoverable directly from the GitHub repo page.

## Changes

- Added a `docs-tribalmind.dev` badge (indigo `#6366f1`) to the README badge row, linking to the docs introduction page

## How to test

1. View the README on the branch — confirm the badge renders and links correctly

## Checklist

- [x] I have tested these changes locally
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)