### PR TITLE
fix: gracefully handle missing keyring backend on Linux

### DIFF
--- a/lib/tribalmind/cli/config_cmd.py
+++ b/lib/tribalmind/cli/config_cmd.py
@@ -133,10 +133,16 @@ def config_set_secret(
         raise typer.Exit(1)
 
     credential_key = SECRET_KEYS[name]
-    set_credential(credential_key, value)
+    stored_in_keyring = set_credential(credential_key, value)
+    if not stored_in_keyring:
+        config_path = _get_config_path()
+        data = _load_config_file(config_path)
+        data[credential_key] = value.strip()
+        _save_config_file(config_path, data)
     clear_settings_cache()
     masked = value[:4] + "\u2022" * 8 + value[-4:]
-    console.print(f"[green]Stored[/green] {name} in system keyring: {masked}")
+    location = "system keyring" if stored_in_keyring else "config file"
+    console.print(f"[green]Stored[/green] {name} in {location}: {masked}")
 
 
 @config_app.command("assistants")

--- a/lib/tribalmind/cli/init_cmd.py
+++ b/lib/tribalmind/cli/init_cmd.py
@@ -113,11 +113,20 @@ def init(
     )
     from tribalmind.config.settings import clear_settings_cache
 
+    def _store_api_key(key_value: str) -> None:
+        """Store API key in keyring, falling back to config file."""
+        stored = set_credential(BACKBOARD_API_KEY, key_value)
+        if not stored:
+            cfg_path = _get_config_path()
+            cfg = _load_config_file(cfg_path)
+            cfg["backboard_api_key"] = key_value.strip()
+            _save_config_file(cfg_path, cfg)
+        clear_settings_cache()
+
     # ── Step 1: API key ─────────────────────────────────────────────────────
     console.print(f"\n{_STEP}Step 1/4[/{_STEP[1:]}  [bold]API Key[/bold]")
     if api_key:
-        set_credential(BACKBOARD_API_KEY, api_key)
-        clear_settings_cache()
+        _store_api_key(api_key)
         console.print(f"  {_CHECK} API key stored.")
     elif get_backboard_api_key():
         console.print(f"  {_CHECK} API key already configured.")
@@ -154,9 +163,8 @@ def init(
                 raise typer.Exit(1)
             # Other errors (network, etc.) — don't block init, key format is fine
 
-        set_credential(BACKBOARD_API_KEY, api_key)
-        clear_settings_cache()
-        console.print(f"  {_CHECK} API key stored in system keyring.")
+        _store_api_key(api_key)
+        console.print(f"  {_CHECK} API key stored.")
 
     # ── Step 2: LLM provider ────────────────────────────────────────────────
     console.print(f"\n{_STEP}Step 2/4[/{_STEP[1:]}  [bold]LLM Provider[/bold]")

--- a/lib/tribalmind/config/credentials.py
+++ b/lib/tribalmind/config/credentials.py
@@ -1,12 +1,14 @@
 """Credential management using system keyring.
 
 Stores API keys in the OS-native credential store (Windows Credential Manager,
-macOS Keychain, Linux Secret Service). Falls back to environment variables / config.
+macOS Keychain, Linux Secret Service). Falls back to environment variables / config
+when no keyring backend is available (common on minimal Linux installs like Arch).
 """
 
 from __future__ import annotations
 
 import keyring
+import keyring.errors
 from rich.console import Console
 
 SERVICE_PREFIX = "tribalmind"
@@ -16,19 +18,45 @@ BACKBOARD_API_KEY = "backboard_api_key"
 
 console = Console(stderr=True)
 
+_keyring_warned = False
+
+
+def _warn_no_keyring() -> None:
+    global _keyring_warned
+    if not _keyring_warned:
+        console.print(
+            "[yellow]Warning:[/yellow] No system keyring backend found. "
+            "Credentials will fall back to config file / environment variables.\n"
+            "To enable keyring support, install a secret-service provider "
+            "(e.g. gnome-keyring, kwallet) or the keyrings.alt package."
+        )
+        _keyring_warned = True
+
 
 def _service_name(key: str) -> str:
     return f"{SERVICE_PREFIX}:{key}"
 
 
-def set_credential(key: str, value: str) -> None:
-    """Store a credential in the system keyring."""
-    keyring.set_password(_service_name(key), key, value.strip())
+def set_credential(key: str, value: str) -> bool:
+    """Store a credential in the system keyring.
+
+    Returns True if stored successfully, False if keyring is unavailable.
+    """
+    try:
+        keyring.set_password(_service_name(key), key, value.strip())
+        return True
+    except keyring.errors.NoKeyringError:
+        _warn_no_keyring()
+        return False
 
 
 def get_credential(key: str) -> str | None:
     """Retrieve a credential from the system keyring."""
-    value = keyring.get_password(_service_name(key), key)
+    try:
+        value = keyring.get_password(_service_name(key), key)
+    except keyring.errors.NoKeyringError:
+        _warn_no_keyring()
+        return None
     return value.strip() if value else value
 
 
@@ -36,7 +64,7 @@ def delete_credential(key: str) -> None:
     """Remove a credential from the system keyring."""
     try:
         keyring.delete_password(_service_name(key), key)
-    except keyring.errors.PasswordDeleteError:
+    except (keyring.errors.PasswordDeleteError, keyring.errors.NoKeyringError):
         pass
 
 


### PR DESCRIPTION
## Summary
- On minimal Linux installs (e.g. Arch), `tribal init` crashes with `NoKeyringError` because no secret-service provider (GNOME Keyring, KWallet, etc.) is available
- `credentials.py` now catches `NoKeyringError` in all keyring operations and prints a one-time warning instead of crashing
- `set_credential` returns a `bool` indicating success; when `False`, both `init_cmd` and `config_cmd` fall back to persisting credentials in `.tribal/config.yaml`

## Test plan
- [x] All 55 existing tests pass (ruff clean, pytest green)
- [ ] Verify on a machine without a keyring backend (e.g. Arch minimal, headless Ubuntu) that `tribal init` completes and stores the API key in `.tribal/config.yaml`
- [ ] Verify on macOS / desktop Linux that keyring storage still works as before

Made with [Cursor](https://cursor.com)