### PR TITLE
feat: include fastapi and uvicorn in core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "keyring>=25",
     "platformdirs>=4",
     "questionary>=2.1",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.29",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- `fastapi` and `uvicorn[standard]` moved from the optional `[ui]` extra to core dependencies
- `tribal ui` now works out of the box with a plain `pip install tribalmind`
- The `[ui]` extra is retained for backwards compatibility

## Motivation

`tribal ui` is a first-class CLI command but silently failed unless users knew to install `tribalmind[ui]`. This was especially painful for pipx users, who had to run `pipx inject tribalmind fastapi uvicorn` as a separate step.

## Test plan

- [ ] `pip install tribalmind` then `tribal ui` launches without error
- [ ] `pip install 'tribalmind[ui]'` still resolves cleanly (no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)