### PR TITLE
chore: ignore .cursor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tribal.yaml
 *.swp
 *.swo
 *~
+.cursor
 
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary
- Adds `.cursor` to `.gitignore` to prevent Cursor IDE files (rules, settings) from being committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)