### PR TITLE
feat: auto-update CLAUDE.md and agents.md on tribal upgrade

### DIFF
--- a/lib/tribalmind/cli/agents_cmd.py
+++ b/lib/tribalmind/cli/agents_cmd.py
@@ -9,6 +9,11 @@ from rich.console import Console
 
 console = Console()
 
+# ── Markers for auto-update detection ──────────────────────────────────────
+
+MARKER_START = "<!-- tribalmind:start -->"
+MARKER_END = "<!-- tribalmind:end -->"
+
 # ── Shared building blocks ──────────────────────────────────────────────────
 
 _RECALL_SECTION = """\
@@ -79,6 +84,7 @@ Pipe via stdin: `echo "insight" | tribal remember`"""
 # ── Provider-specific snippets ──────────────────────────────────────────────
 
 SNIPPET_CLAUDE_CODE = f"""\
+{MARKER_START}
 ## TribalMind — Project Memory
 
 This project uses [TribalMind](https://github.com/zachary-nguyen/TribalMind) \
@@ -95,9 +101,11 @@ that all agents and team members can access.
 
 {_REMEMBER_SECTION}
 
-{_REFERENCE_SECTION}"""
+{_REFERENCE_SECTION}
+{MARKER_END}"""
 
 SNIPPET_DEFAULT = f"""\
+{MARKER_START}
 ## TribalMind — Project Memory
 
 This project uses [TribalMind](https://github.com/zachary-nguyen/TribalMind) \
@@ -110,7 +118,8 @@ to persist and retrieve knowledge across sessions.
 
 {_REMEMBER_SECTION}
 
-{_REFERENCE_SECTION}"""
+{_REFERENCE_SECTION}
+{MARKER_END}"""
 
 AGENT_SNIPPETS: dict[str, str] = {
     "claude-code": SNIPPET_CLAUDE_CODE,
@@ -180,12 +189,33 @@ def _detect_agents(root: Path) -> list[str]:
 def _inject_snippet(file_path: Path, snippet: str, marker: str) -> str:
     """Append or replace the TribalMind section in a file.
 
+    Detection order:
+    1. HTML markers (<!-- tribalmind:start --> / <!-- tribalmind:end -->)
+    2. Legacy heading-based detection (## TribalMind ... next ## heading)
+    3. Append if neither found
+
     Returns: 'created', 'updated', or 'unchanged'.
     """
     if file_path.exists():
         content = file_path.read_text(encoding="utf-8")
+
+        # ── Strategy 1: HTML marker-based replacement ──────────────────
+        if MARKER_START in content and MARKER_END in content:
+            start = content.index(MARKER_START)
+            end = content.index(MARKER_END) + len(MARKER_END)
+            before = content[:start].rstrip()
+            after = content[end:].lstrip()
+            parts = [before, snippet.rstrip()]
+            if after:
+                parts.append(after)
+            new_content = "\n\n".join(parts) + "\n"
+            if new_content.strip() == content.strip():
+                return "unchanged"
+            file_path.write_text(new_content, encoding="utf-8")
+            return "updated"
+
+        # ── Strategy 2: Legacy heading-based replacement ───────────────
         if marker in content:
-            # Replace existing section: from marker to next ## heading or EOF
             start = content.index(marker)
             rest = content[start + len(marker) :]
             # Find the next same-level heading (## ) or EOF
@@ -210,14 +240,14 @@ def _inject_snippet(file_path: Path, snippet: str, marker: str) -> str:
                 return "unchanged"
             file_path.write_text(new_content, encoding="utf-8")
             return "updated"
-        else:
-            # Append
-            separator = "\n\n" if content.rstrip() else ""
-            file_path.write_text(
-                content.rstrip() + separator + snippet.rstrip() + "\n",
-                encoding="utf-8",
-            )
-            return "updated"
+
+        # ── Strategy 3: Append ─────────────────────────────────────────
+        separator = "\n\n" if content.rstrip() else ""
+        file_path.write_text(
+            content.rstrip() + separator + snippet.rstrip() + "\n",
+            encoding="utf-8",
+        )
+        return "updated"
     else:
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(snippet.rstrip() + "\n", encoding="utf-8")

--- a/lib/tribalmind/cli/upgrade_cmd.py
+++ b/lib/tribalmind/cli/upgrade_cmd.py
@@ -6,17 +6,90 @@ import subprocess
 import sys
 
 import typer
+from rich.console import Console
+
+console = Console()
+
+_CHECK = "[bold #34d399]\u2714[/bold #34d399]"
 
 
-def upgrade() -> None:
+def _update_agent_docs() -> list[tuple[str, str]]:
+    """Detect and update TribalMind instruction blocks in agent config files.
+
+    Scans the current project for known agent config files (CLAUDE.md,
+    AGENTS.md, etc.) and replaces the TribalMind section with the latest
+    template.
+
+    Returns a list of (file_path, result) tuples where result is one of
+    'created', 'updated', or 'unchanged'.
+    """
+    from tribalmind.cli.agents_cmd import (
+        AGENT_SNIPPETS,
+        AGENTS,
+        _detect_agents,
+        _find_project_root,
+        _inject_snippet,
+    )
+
+    root = _find_project_root()
+    detected = _detect_agents(root)
+
+    if not detected:
+        return []
+
+    results = []
+    for key in detected:
+        info = AGENTS[key]
+        file_path = root / info["path"]
+        snippet = AGENT_SNIPPETS[info["snippet_key"]]
+        result = _inject_snippet(file_path, snippet, info["section_marker"])
+        results.append((info["path"], result))
+
+    return results
+
+
+def upgrade(
+    no_update_docs: bool = typer.Option(
+        False,
+        "--no-update-docs",
+        help="Skip auto-updating agent config files (CLAUDE.md, AGENTS.md, etc.).",
+    ),
+) -> None:
     """Upgrade TribalMind to the latest version from PyPI.
 
-    Runs: pip install -U tribalmind
+    After upgrading the package, automatically updates any agent config files
+    (CLAUDE.md, AGENTS.md, etc.) to match the latest TribalMind instruction
+    template.  Use --no-update-docs to skip this step.
     """
-    typer.echo("Upgrading TribalMind...")
+    console.print("Upgrading TribalMind...")
     result = subprocess.run(
         [sys.executable, "-m", "pip", "install", "-U", "tribalmind"],
         capture_output=False,
     )
     if result.returncode != 0:
         raise typer.Exit(result.returncode)
+
+    if no_update_docs:
+        console.print("\n[dim]Skipped agent doc updates (--no-update-docs).[/dim]")
+        return
+
+    # Auto-update agent config files
+    console.print("\n[bold]Updating agent config files...[/bold]")
+    doc_results = _update_agent_docs()
+
+    if not doc_results:
+        console.print("  [dim]No agent config files detected in this project.[/dim]")
+        return
+
+    any_updated = False
+    for path, status in doc_results:
+        if status == "updated":
+            console.print(f"  {_CHECK} [yellow]updated[/yellow]  {path}")
+            any_updated = True
+        elif status == "unchanged":
+            console.print(f"  {_CHECK} [dim]unchanged[/dim]  {path}")
+
+    if any_updated:
+        console.print(
+            "\n[dim]Tip: review the updated files and commit them to your repo.[/dim]"
+        )


### PR DESCRIPTION
## Description

When a user runs `tribal upgrade`, their agent config files (CLAUDE.md, AGENTS.md, etc.) may contain outdated TribalMind instructions. This PR makes the upgrade command automatically detect and update these files to match the latest version's template.

## Motivation

Closes #26

## Changes

- Added `<!-- tribalmind:start -->` / `<!-- tribalmind:end -->` HTML markers to all snippet templates so the TribalMind block can be reliably detected and replaced
- Updated `_inject_snippet` with a 3-tier detection strategy: (1) HTML markers, (2) legacy heading-based detection for pre-marker files, (3) append if neither found
- Enhanced `tribal upgrade` to auto-scan the project for existing agent config files and update their TribalMind sections after the pip upgrade completes
- Added `--no-update-docs` flag to opt out of automatic doc updates

## How to test

1. Run `tribal setup-agents` in a project — verify the generated files now include `<!-- tribalmind:start -->` and `<!-- tribalmind:end -->` markers
2. Manually edit the TribalMind section in a generated file (e.g., change some text in CLAUDE.md)
3. Run `tribal upgrade` — verify the section is restored to the latest template and a summary is shown
4. Run `tribal upgrade --no-update-docs` — verify agent files are not touched
5. Test with a legacy file (no HTML markers, just the `## TribalMind` heading) — verify the heading-based fallback still works

## Checklist

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors