### PR TITLE
chore: remove dead team_sharing_enabled references

### DIFF
--- a/tests/unit/test_cli/test_recall.py
+++ b/tests/unit/test_cli/test_recall.py
@@ -39,7 +39,6 @@ class TestRecallCommand:
     @patch("tribalmind.config.settings.get_settings")
     def test_recall_basic(self, mock_settings, mock_search):
         mock_settings.return_value.project_assistant_id = "ast-123"
-        mock_settings.return_value.team_sharing_enabled = False
         mock_settings.return_value.org_assistant_id = None
         mock_search.return_value = [_make_memory()]
 
@@ -52,7 +51,6 @@ class TestRecallCommand:
     @patch("tribalmind.config.settings.get_settings")
     def test_recall_json_output(self, mock_settings, mock_search):
         mock_settings.return_value.project_assistant_id = "ast-123"
-        mock_settings.return_value.team_sharing_enabled = False
         mock_settings.return_value.org_assistant_id = None
         mock_search.return_value = [_make_memory()]
 
@@ -67,7 +65,6 @@ class TestRecallCommand:
     @patch("tribalmind.config.settings.get_settings")
     def test_recall_no_results(self, mock_settings, mock_search):
         mock_settings.return_value.project_assistant_id = "ast-123"
-        mock_settings.return_value.team_sharing_enabled = False
         mock_settings.return_value.org_assistant_id = None
         mock_search.return_value = []
 
@@ -91,7 +88,6 @@ class TestRecallCommand:
     @patch("tribalmind.config.settings.get_settings")
     def test_recall_stdin(self, mock_settings, mock_search):
         mock_settings.return_value.project_assistant_id = "ast-123"
-        mock_settings.return_value.team_sharing_enabled = False
         mock_settings.return_value.org_assistant_id = None
         mock_search.return_value = [_make_memory()]
 


### PR DESCRIPTION
## Description

Remove dead `team_sharing_enabled` references from the test suite. Team sharing is controlled by sharing the same Backboard API key — there is no separate toggle.

## Motivation

Closes #18

## Changes

- Removed 4 instances of `mock_settings.return_value.team_sharing_enabled = False` from `tests/unit/test_cli/test_recall.py`
- Searched entire codebase — no other `team_sharing` references exist

## How to test

1. Run the test suite: `pytest tests/unit/test_cli/test_recall.py`
2. Verify no references remain: `grep -r "team_sharing" .`

## Checklist

- [x] I have tested these changes locally
- [x] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My changes do not introduce new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)