### PR TITLE
feat: pluggable memory provider abstraction

### DIFF
--- a/lib/tribalmind/cli/config_cmd.py
+++ b/lib/tribalmind/cli/config_cmd.py
@@ -25,13 +25,14 @@ SECRET_KEYS = {
 
 # Settings fields that can be modified via `tribal config set`
 CONFIGURABLE_KEYS = {
+    "provider": "provider",
     "backboard-base-url": "backboard_base_url",
     "llm-provider": "llm_provider",
     "model-name": "model_name",
     "project-assistant-id": "project_assistant_id",
 }
 
-REDACTED_FIELDS = {"backboard_api_key"}
+REDACTED_FIELDS = {"backboard_api_key", "mem0_api_key"}
 
 
 def _get_config_path() -> Path:
@@ -193,8 +194,7 @@ def config_clear_memory(
     """Clear ALL memories for an assistant."""
     import asyncio
 
-    from tribalmind.backboard.client import BackboardError, create_client
-    from tribalmind.backboard.memory import clear_memories
+    from tribalmind.providers import get_provider
 
     settings = TribalSettings()
     target_id = assistant_id or settings.project_assistant_id
@@ -212,15 +212,20 @@ def config_clear_memory(
             raise typer.Abort()
 
     async def _clear():
-        async with create_client() as client:
-            return await clear_memories(client, target_id)
+        provider = get_provider()
+        async with provider:
+            return await provider.clear()
 
     try:
         deleted = asyncio.run(_clear())
         console.print(f"[green]Cleared[/green] {deleted} memories from assistant {target_id}")
-    except BackboardError as e:
-        console.print(f"[red]API error {e.status_code}:[/red] {e.detail}")
-        raise typer.Exit(1)
+    except Exception as e:
+        from tribalmind.backboard.client import BackboardError
+
+        if isinstance(e, BackboardError):
+            console.print(f"[red]API error {e.status_code}:[/red] {e.detail}")
+            raise typer.Exit(1)
+        raise
 
 
 @config_app.command("debug-key")

--- a/lib/tribalmind/cli/forget_cmd.py
+++ b/lib/tribalmind/cli/forget_cmd.py
@@ -9,6 +9,8 @@ import sys
 import typer
 from rich.console import Console
 
+from tribalmind.providers import get_provider
+
 console = Console()
 
 
@@ -43,12 +45,6 @@ def forget(
         tribal forget --all --yes               # clear everything
         echo "outdated webpack tip" | tribal forget --yes
     """
-    from tribalmind.backboard.client import BackboardError, create_client
-    from tribalmind.backboard.memory import (
-        clear_memories,
-        delete_memory,
-        search_memories,
-    )
     from tribalmind.config.settings import get_settings
 
     settings = get_settings()
@@ -62,8 +58,9 @@ def forget(
         # Mode 1: Delete by ID
         if memory_id:
             async def _delete_by_id() -> None:
-                async with create_client() as client:
-                    await delete_memory(client, assistant_id, memory_id)
+                provider = get_provider()
+                async with provider:
+                    await provider.delete(memory_id)
 
             asyncio.run(_delete_by_id())
 
@@ -90,8 +87,9 @@ def forget(
                     raise typer.Abort()
 
             async def _clear() -> int:
-                async with create_client() as client:
-                    return await clear_memories(client, assistant_id)
+                provider = get_provider()
+                async with provider:
+                    return await provider.clear()
 
             deleted = asyncio.run(_clear())
 
@@ -125,8 +123,9 @@ def forget(
             raise typer.Exit(1)
 
         async def _search_and_delete() -> list[str]:
-            async with create_client() as client:
-                results = await search_memories(client, assistant_id, query_text, limit=10)
+            provider = get_provider()
+            async with provider:
+                results = await provider.search(query_text, limit=10)
                 if not results:
                     return []
 
@@ -142,7 +141,7 @@ def forget(
                 deleted_ids = []
                 for r in results:
                     if r.memory_id:
-                        await delete_memory(client, assistant_id, r.memory_id)
+                        await provider.delete(r.memory_id)
                         deleted_ids.append(r.memory_id)
                 return deleted_ids
 
@@ -164,6 +163,11 @@ def forget(
         else:
             console.print("[dim]No matching memories found.[/dim]")
 
-    except BackboardError as e:
-        console.print(f"[red]API error {e.status_code}:[/red] {e.detail}")
-        raise typer.Exit(1)
+    except Exception as e:
+        # Handle provider-specific errors
+        from tribalmind.backboard.client import BackboardError
+
+        if isinstance(e, BackboardError):
+            console.print(f"[red]API error {e.status_code}:[/red] {e.detail}")
+            raise typer.Exit(1)
+        raise

--- a/lib/tribalmind/cli/init_cmd.py
+++ b/lib/tribalmind/cli/init_cmd.py
@@ -13,6 +13,7 @@ console = Console()
 # Step label style
 _STEP = "[bold #818cf8]"
 _CHECK = "[bold #34d399]\u2714[/bold #34d399]"
+_TOTAL_STEPS = 6
 
 
 def _detect_shell() -> str | None:
@@ -83,6 +84,11 @@ def _get_global_config_path() -> Path:
     return config_dir / "tribal.yaml"
 
 
+def _step(num: int, label: str) -> None:
+    """Print a step header."""
+    console.print(f"\n{_STEP}Step {num}/{_TOTAL_STEPS}[/{_STEP[1:]}  [bold]{label}[/bold]")
+
+
 def init(
     api_key: str | None = typer.Option(  # noqa: UP007
         None, "--api-key", "-k",
@@ -105,11 +111,15 @@ def init(
         None, "--model-name",
         help="LLM model name (for non-interactive use).",
     ),
+    provider_opt: str | None = typer.Option(  # noqa: UP007
+        None, "--provider",
+        help="Memory provider: backboard, mem0 (for non-interactive / agent use).",
+    ),
 ) -> None:
     """Initialize TribalMind for the current project (or globally).
 
-    Sets up the Backboard API key (if needed) and creates a Backboard assistant
-    for storing memories.
+    Sets up the memory provider and credentials, then creates a project
+    assistant for storing memories.
 
     \b
     Modes:
@@ -121,11 +131,12 @@ def init(
     Examples:
         tribal init                        # set up this repo
         tribal init --global               # set up user-level default
-        tribal init --api-key sk-xxx       # non-interactive
+        tribal init --api-key sk-xxx       # non-interactive (Backboard)
+        tribal init --provider mem0        # use Mem0 backend
         tribal init --project-root /path   # specific project
     """
     from tribalmind.cli.banner import print_banner
-    print_banner(compact=bool(api_key))
+    print_banner(compact=bool(api_key or provider_opt))
 
     from tribalmind.backboard.client import BackboardError
     from tribalmind.cli.config_cmd import _get_config_path, _load_config_file, _save_config_file
@@ -135,6 +146,10 @@ def init(
         set_credential,
     )
     from tribalmind.config.settings import clear_settings_cache
+    from tribalmind.providers.factory import get_provider_choices
+
+    # Non-interactive flag: True when --api-key or --provider is passed
+    non_interactive = bool(api_key or provider_opt)
 
     def _store_api_key(key_value: str) -> None:
         """Store API key in keyring, falling back to config file."""
@@ -146,51 +161,157 @@ def init(
             _save_config_file(cfg_path, cfg)
         clear_settings_cache()
 
-    # ── Step 1: API key ─────────────────────────────────────────────────────
-    console.print(f"\n{_STEP}Step 1/5[/{_STEP[1:]}  [bold]API Key[/bold]")
-    if api_key:
-        _store_api_key(api_key)
-        console.print(f"  {_CHECK} API key stored.")
-    elif get_backboard_api_key():
-        console.print(f"  {_CHECK} API key already configured.")
-    else:
-        api_key = typer.prompt("  Enter your Backboard API key", hide_input=True)
-        api_key = api_key.strip() if api_key else ""
-        if not api_key or len(api_key) < 8:
-            console.print("  [red]Invalid API key.[/red]")
-            console.print(
-                "  [dim]Paste not working? Use:[/dim] "
-                "[#a78bfa]tribal init --api-key YOUR_KEY[/#a78bfa]"
-            )
+    # ── Step 1: Memory Provider Selection ──────────────────────────────────
+    _step(1, "Memory Provider")
+
+    # Check if re-running init on an existing project
+    existing_config_path = _get_config_path()
+    existing_config = _load_config_file(existing_config_path)
+    existing_provider = existing_config.get("provider", "")
+
+    if provider_opt:
+        # Non-interactive: validate provider name
+        available_names = [name for _, name, _ in get_provider_choices()]
+        if provider_opt not in available_names:
+            console.print(f"  [red]Unknown provider: {provider_opt}[/red]")
+            console.print(f"  Available: {', '.join(available_names)}")
             raise typer.Exit(1)
+        selected_provider = provider_opt
+        console.print(f"  {_CHECK} Using [#a78bfa]{selected_provider}[/#a78bfa] provider")
+    elif non_interactive:
+        # --api-key without --provider → default to backboard
+        selected_provider = existing_provider or "backboard"
+        console.print(f"  {_CHECK} Using [#a78bfa]{selected_provider}[/#a78bfa] provider")
+    else:
+        from tribalmind.cli.prompts import select
 
-        # Validate the key against the API before storing
-        try:
-            from tribalmind.backboard.client import BackboardClient, BackboardError
-            from tribalmind.config.settings import get_settings
+        provider_choices = [
+            (label, name)
+            for label, name, coming_soon in get_provider_choices()
+            if not coming_soon
+        ]
 
-            settings = get_settings()
+        if existing_provider:
+            console.print(
+                f"  [dim]Current provider:[/dim] [#a78bfa]{existing_provider}[/#a78bfa]"
+            )
 
-            async def _validate_key() -> None:
-                async with BackboardClient(settings.backboard_base_url, api_key) as c:
-                    await c.get("/assistants")
+        selected_provider = select(
+            "  Select memory provider:",
+            choices=provider_choices,
+            default=existing_provider or "backboard",
+        )
 
-            asyncio.run(_validate_key())
-        except BackboardError as e:
-            if e.status_code == 401:
-                console.print(f"  [red]API key rejected by Backboard:[/red] {e.detail}")
+        if selected_provider is None:
+            raise typer.Exit()
+        console.print(f"  {_CHECK} Selected [#a78bfa]{selected_provider}[/#a78bfa]")
+
+    # ── Step 2: Provider Credentials ───────────────────────────────────────
+    _step(2, "Credentials")
+
+    if selected_provider == "backboard":
+        # Backboard API key setup (existing logic)
+        if api_key:
+            _store_api_key(api_key)
+            console.print(f"  {_CHECK} Backboard API key stored.")
+        elif get_backboard_api_key():
+            console.print(f"  {_CHECK} Backboard API key already configured.")
+        else:
+            api_key = typer.prompt("  Enter your Backboard API key", hide_input=True)
+            api_key = api_key.strip() if api_key else ""
+            if not api_key or len(api_key) < 8:
+                console.print("  [red]Invalid API key.[/red]")
                 console.print(
                     "  [dim]Paste not working? Use:[/dim] "
                     "[#a78bfa]tribal init --api-key YOUR_KEY[/#a78bfa]"
                 )
                 raise typer.Exit(1)
-            # Other errors (network, etc.) — don't block init, key format is fine
 
-        _store_api_key(api_key)
-        console.print(f"  {_CHECK} API key stored.")
+            # Validate the key against the API before storing
+            try:
+                from tribalmind.backboard.client import BackboardClient
+                from tribalmind.config.settings import get_settings
 
-    # ── Step 2: LLM provider ────────────────────────────────────────────────
-    console.print(f"\n{_STEP}Step 2/5[/{_STEP[1:]}  [bold]LLM Provider[/bold]")
+                settings = get_settings()
+
+                async def _validate_key() -> None:
+                    async with BackboardClient(settings.backboard_base_url, api_key) as c:
+                        await c.get("/assistants")
+
+                asyncio.run(_validate_key())
+            except BackboardError as e:
+                if e.status_code == 401:
+                    console.print(
+                        f"  [red]API key rejected by Backboard:[/red] {e.detail}"
+                    )
+                    console.print(
+                        "  [dim]Paste not working? Use:[/dim] "
+                        "[#a78bfa]tribal init --api-key YOUR_KEY[/#a78bfa]"
+                    )
+                    raise typer.Exit(1)
+                # Other errors (network, etc.) — don't block init
+
+            _store_api_key(api_key)
+            console.print(f"  {_CHECK} Backboard API key stored.")
+
+    elif selected_provider == "mem0":
+        # Mem0 credentials
+        from tribalmind.config.settings import get_settings
+
+        settings = get_settings()
+        mem0_key = settings.mem0_api_key
+
+        if not mem0_key:
+            import os
+
+            mem0_key = os.environ.get("TRIBAL_MEM0_API_KEY", "")
+
+        if mem0_key:
+            console.print(f"  {_CHECK} Mem0 API key already configured.")
+        else:
+            mem0_key = typer.prompt("  Enter your Mem0 API key", hide_input=True)
+            mem0_key = mem0_key.strip() if mem0_key else ""
+            if not mem0_key or len(mem0_key) < 8:
+                console.print("  [red]Invalid Mem0 API key.[/red]")
+                raise typer.Exit(1)
+
+        # Optional: org_id and project_id (Mem0 requires both or neither)
+        mem0_org_id = settings.mem0_org_id
+        mem0_project_id = settings.mem0_project_id
+
+        if not non_interactive and not (mem0_org_id and mem0_project_id):
+            mem0_org_id = typer.prompt(
+                "  Mem0 org ID (optional, press Enter to skip)", default=""
+            ).strip()
+            if mem0_org_id:
+                mem0_project_id = typer.prompt(
+                    "  Mem0 project ID (required with org ID)", default=""
+                ).strip()
+                if not mem0_project_id:
+                    console.print(
+                        "  [yellow]Project ID is required when org ID is set."
+                        " Skipping both.[/yellow]"
+                    )
+                    mem0_org_id = ""
+            else:
+                mem0_project_id = ""
+
+        # Store Mem0 credentials in config file
+        cfg_path = _get_config_path()
+        cfg = _load_config_file(cfg_path)
+        cfg["mem0_api_key"] = mem0_key
+        if mem0_org_id and mem0_project_id:
+            cfg["mem0_org_id"] = mem0_org_id
+            cfg["mem0_project_id"] = mem0_project_id
+        _save_config_file(cfg_path, cfg)
+        clear_settings_cache()
+        console.print(f"  {_CHECK} Mem0 credentials stored.")
+
+    else:
+        console.print(f"  {_CHECK} No credentials needed for {selected_provider}.")
+
+    # ── Step 3: LLM provider ────────────────────────────────────────────────
+    _step(3, "LLM Provider")
 
     # Determine scope and project root
     if global_init:
@@ -206,7 +327,7 @@ def init(
             else:
                 root = Path.cwd()
                 console.print(
-                    f"\n  [yellow]⚠  No git repository detected.[/yellow]"
+                    f"\n  [yellow]\u26a0  No git repository detected.[/yellow]"
                     f"  Assistant will be named [bold]{root.name}[/bold] (directory name)."
                 )
                 from tribalmind.cli.prompts import confirm
@@ -230,7 +351,7 @@ def init(
 
     if llm_provider and model_name:
         console.print(f"  {_CHECK} Using {llm_provider}/{model_name}")
-    elif not api_key:
+    elif not non_interactive:
         from tribalmind.cli.prompts import select
 
         llm_choices = [
@@ -254,18 +375,36 @@ def init(
 
         console.print(f"  {_CHECK} Using [#a78bfa]{llm_provider}/{model_name}[/#a78bfa]")
 
-    # ── Step 3: Create assistant ────────────────────────────────────────────
-    console.print(f"\n{_STEP}Step 3/5[/{_STEP[1:]}  [bold]Project Setup[/bold]")
-    try:
-        assistant = asyncio.run(_setup_assistant(assistant_root))
-    except BackboardError as e:
-        console.print(f"  [red]Backboard API error {e.status_code}:[/red] {e.detail}")
-        raise typer.Exit(1)
+    # ── Step 4: Project Setup ──────────────────────────────────────────────
+    _step(4, "Project Setup")
 
-    assistant_id = assistant.get("assistant_id", "")
-    if not assistant_id:
-        console.print("  [red]Failed to create assistant \u2014 no ID returned.[/red]")
-        raise typer.Exit(1)
+    assistant_id = ""
+    if selected_provider == "backboard":
+        # Backboard: create/find assistant via API
+        try:
+            assistant = asyncio.run(_setup_assistant(assistant_root))
+        except BackboardError as e:
+            console.print(
+                f"  [red]Backboard API error {e.status_code}:[/red] {e.detail}"
+            )
+            raise typer.Exit(1)
+
+        assistant_id = assistant.get("assistant_id", "")
+        if not assistant_id:
+            console.print("  [red]Failed to create assistant \u2014 no ID returned.[/red]")
+            raise typer.Exit(1)
+    else:
+        # Non-Backboard providers: use git hash or directory name as project ID
+        import hashlib
+
+        if assistant_root == "global":
+            assistant_id = "global"
+        else:
+            # Generate a stable project ID from the path
+            assistant_id = hashlib.sha256(
+                assistant_root.encode()
+            ).hexdigest()[:12]
+        console.print(f"  {_CHECK} Project ID: [#a78bfa]{assistant_id}[/#a78bfa]")
 
     # Save config (global: tribal.yaml in user config dir, per-repo: .tribal/config.yaml)
     if global_init:
@@ -273,6 +412,7 @@ def init(
     else:
         config_path = _get_config_path()
     data = _load_config_file(config_path)
+    data["provider"] = selected_provider
     data["project_assistant_id"] = assistant_id
     if llm_provider:
         data["llm_provider"] = llm_provider
@@ -285,10 +425,16 @@ def init(
 
     if global_init:
         console.print(f"  {_CHECK} Initialized globally")
+        console.print(
+            f"     [dim]provider:[/dim]  [#a78bfa]{selected_provider}[/#a78bfa]"
+        )
         console.print(f"     [dim]assistant:[/dim] [#a78bfa]{assistant_id}[/#a78bfa]")
         console.print(f"     [dim]config:[/dim]    {config_path}")
     else:
         console.print(f"  {_CHECK} Initialized for [bold]{root_label}[/bold]")
+        console.print(
+            f"     [dim]provider:[/dim]  [#a78bfa]{selected_provider}[/#a78bfa]"
+        )
         console.print(f"     [dim]assistant:[/dim] [#a78bfa]{assistant_id}[/#a78bfa]")
         console.print(f"     [dim]config:[/dim]    {config_path}")
 
@@ -297,9 +443,9 @@ def init(
             if _ensure_gitignore(root):
                 console.print(f"  {_CHECK} Added [bold].tribal/[/bold] to .gitignore")
 
-    # ── Step 4: Agent integration files ─────────────────────────────────────
-    console.print(f"\n{_STEP}Step 4/5[/{_STEP[1:]}  [bold]Agent Integration[/bold]")
-    if api_key:
+    # ── Step 5: Agent integration files ─────────────────────────────────────
+    _step(5, "Agent Integration")
+    if non_interactive:
         console.print(f"  {_CHECK} Skipped (non-interactive mode)")
     else:
         from tribalmind.cli.prompts import confirm
@@ -347,9 +493,9 @@ def init(
         else:
             console.print("  [dim]Skipped.[/dim]")
 
-    # ── Step 5: Shell completions ────────────────────────────────────────────
-    console.print(f"\n{_STEP}Step 5/5[/{_STEP[1:]}  [bold]Shell Completions[/bold]")
-    if api_key:
+    # ── Step 6: Shell completions ────────────────────────────────────────────
+    _step(6, "Shell Completions")
+    if non_interactive:
         console.print(f"  {_CHECK} Skipped (non-interactive mode)")
         console.print(
             "     [dim]Install later with:[/dim] "
@@ -402,7 +548,7 @@ def init(
 
     # ── Done ────────────────────────────────────────────────────────────────
     console.print()
-    console.print("[bold #34d399]Setup complete![/bold #34d399]")
+    console.print(f"[bold #34d399]Setup complete![/bold #34d399]  (provider: {selected_provider})")
     console.print()
     console.print("  [dim]Get started:[/dim]")
     console.print('  [#a78bfa]tribal remember[/#a78bfa] "your first piece of knowledge"')

--- a/lib/tribalmind/cli/recall_cmd.py
+++ b/lib/tribalmind/cli/recall_cmd.py
@@ -22,20 +22,20 @@ def _filter_by_category(results: list, categories: set[str]) -> list:
 
 async def _list_all(assistant_id: str) -> list:
     """List all memories for an assistant (no search, no RAG cost)."""
-    from tribalmind.backboard.client import create_client
-    from tribalmind.backboard.memory import list_memories
+    from tribalmind.providers import get_provider
 
-    async with create_client() as client:
-        return await list_memories(client, assistant_id)
+    provider = get_provider()
+    async with provider:
+        return await provider.list_all()
 
 
 async def _search(assistant_id: str, query: str, limit: int) -> list:
     """Search memories for a single assistant."""
-    from tribalmind.backboard.client import create_client
-    from tribalmind.backboard.memory import search_memories
+    from tribalmind.providers import get_provider
 
-    async with create_client() as client:
-        return await search_memories(client, assistant_id, query, limit=limit)
+    provider = get_provider()
+    async with provider:
+        return await provider.search(query, limit=limit)
 
 
 async def _search_all_assistants(query: str, limit: int) -> list[tuple[str, list]]:

--- a/lib/tribalmind/cli/remember_cmd.py
+++ b/lib/tribalmind/cli/remember_cmd.py
@@ -94,9 +94,13 @@ def _parse_llm_response(content: str) -> dict | None:
 
 
 async def _parse_with_llm(text: str) -> dict | None:
-    """Send text to the LLM for structured parsing."""
-    from tribalmind.backboard.client import create_client
-    from tribalmind.backboard.threads import create_thread, delete_thread, send_message
+    """Send text to the LLM for structured parsing.
+
+    Uses Backboard's thread/message API for the LLM call. If no Backboard API
+    key is configured (e.g. when using Mem0 as the memory provider), returns
+    None so the caller can fall back to raw context storage.
+    """
+    from tribalmind.config.credentials import get_backboard_api_key
     from tribalmind.config.settings import get_settings
 
     settings = get_settings()
@@ -104,47 +108,59 @@ async def _parse_with_llm(text: str) -> dict | None:
     if not assistant_id:
         return None
 
+    # LLM parsing requires a valid Backboard API key — if the user is on a
+    # non-Backboard provider and hasn't configured one, skip gracefully.
+    if not get_backboard_api_key():
+        logger.debug("No Backboard API key configured; skipping LLM parsing")
+        return None
+
+    from tribalmind.backboard.client import create_client
+    from tribalmind.backboard.threads import create_thread, delete_thread, send_message
+
     prompt = _PARSE_PROMPT.format(text=text)
     thread_id = None
 
-    async with create_client() as client:
-        thread = await create_thread(client, assistant_id)
-        thread_id = thread.get("thread_id", "")
+    try:
+        async with create_client() as client:
+            thread = await create_thread(client, assistant_id)
+            thread_id = thread.get("thread_id", "")
 
-        response = await send_message(
-            client,
-            thread_id,
-            prompt,
-            llm_provider=settings.llm_provider,
-            model_name=settings.model_name,
-        )
+            response = await send_message(
+                client,
+                thread_id,
+                prompt,
+                llm_provider=settings.llm_provider,
+                model_name=settings.model_name,
+            )
 
-        # Extract content from response
-        logger.debug("LLM raw response: %s", response)
-        content = response.get("content", "")
-        if not content:
-            messages = response.get("messages", [])
-            if messages:
-                last = messages[-1] if isinstance(messages, list) else messages
-                content = last.get("content", "") if isinstance(last, dict) else str(last)
+            # Extract content from response
+            logger.debug("LLM raw response: %s", response)
+            content = response.get("content", "")
+            if not content:
+                messages = response.get("messages", [])
+                if messages:
+                    last = messages[-1] if isinstance(messages, list) else messages
+                    content = last.get("content", "") if isinstance(last, dict) else str(last)
 
-        logger.debug("Extracted content for parsing: %r", content)
-        result = _parse_llm_response(content)
+            logger.debug("Extracted content for parsing: %r", content)
+            result = _parse_llm_response(content)
 
-        if thread_id:
-            try:
-                await delete_thread(client, thread_id)
-            except Exception:
-                pass
+            if thread_id:
+                try:
+                    await delete_thread(client, thread_id)
+                except Exception:
+                    pass
 
-        return result
+            return result
+    except Exception:
+        logger.debug("Backboard LLM parsing failed", exc_info=True)
+        return None
 
 
 async def _store_memory(text: str) -> dict:
-    """Parse text with LLM and store as a new Backboard memory."""
-    from tribalmind.backboard.client import create_client
-    from tribalmind.backboard.memory import add_memory, encode_memory, enforce_memory_limit
+    """Parse text with LLM and store as a memory via the configured provider."""
     from tribalmind.config.settings import get_settings
+    from tribalmind.providers import get_provider
 
     settings = get_settings()
     assistant_id = settings.project_assistant_id
@@ -153,45 +169,54 @@ async def _store_memory(text: str) -> dict:
         console.print("Run [bold]tribal init[/bold] first to set up your project.")
         raise typer.Exit(1)
 
-    # Parse with LLM
-    parsed = await _parse_with_llm(text)
+    provider = get_provider()
 
-    if not parsed or not parsed.get("content"):
-        # Fallback: store raw text as a 'context' memory
-        logger.debug("LLM parsing failed or returned no content; using fallback")
-        console.print(
-            "[yellow]LLM parsing failed — storing as raw context.[/yellow]"
-        )
-        parsed = {
-            "category": "context",
-            "subject": "",
-            "content": text,
-        }
-    else:
-        # Validate the category returned by the LLM
-        cat = parsed.get("category", "").lower().strip()
-        if cat not in VALID_CATEGORIES:
-            logger.debug("LLM returned invalid category %r; defaulting to 'context'", cat)
-            parsed["category"] = "context"
+    if settings.provider == "backboard":
+        # Backboard: use LLM to parse free-text into structured fields,
+        # then encode as our JSON format before storing.
+        from tribalmind.backboard.memory import encode_memory
 
-    encoded = encode_memory(
-        parsed["category"],
-        subject=parsed.get("subject", ""),
-        content=parsed.get("content", ""),
-    )
+        parsed = await _parse_with_llm(text)
 
-    metadata = {
-        "category": parsed["category"],
-        "subject": parsed.get("subject", ""),
-    }
-
-    async with create_client() as client:
-        await add_memory(client, assistant_id, encoded, metadata=metadata)
-        # Prune oldest memories if over the limit
-        if settings.max_memories_per_assistant > 0:
-            await enforce_memory_limit(
-                client, assistant_id, settings.max_memories_per_assistant
+        if not parsed or not parsed.get("content"):
+            logger.debug("LLM parsing failed or returned no content; using fallback")
+            console.print(
+                "[yellow]LLM parsing failed — storing as raw context.[/yellow]"
             )
+            parsed = {
+                "category": "context",
+                "subject": "",
+                "content": text,
+            }
+        else:
+            cat = parsed.get("category", "").lower().strip()
+            if cat not in VALID_CATEGORIES:
+                logger.debug("LLM returned invalid category %r; defaulting to 'context'", cat)
+                parsed["category"] = "context"
+
+        encoded = encode_memory(
+            parsed["category"],
+            subject=parsed.get("subject", ""),
+            content=parsed.get("content", ""),
+        )
+        metadata = {
+            "category": parsed["category"],
+            "subject": parsed.get("subject", ""),
+        }
+
+        async with provider:
+            await provider.add(encoded, metadata=metadata)
+            if settings.max_memories_per_assistant > 0:
+                await provider.enforce_limit(settings.max_memories_per_assistant)
+    else:
+        # Non-Backboard providers (e.g. Mem0): pass raw text directly.
+        # These providers have their own extraction/categorization pipelines.
+        parsed = {"category": "context", "subject": "", "content": text}
+
+        async with provider:
+            await provider.add(text)
+            if settings.max_memories_per_assistant > 0:
+                await provider.enforce_limit(settings.max_memories_per_assistant)
 
     return parsed
 

--- a/lib/tribalmind/cli/status_cmd.py
+++ b/lib/tribalmind/cli/status_cmd.py
@@ -15,11 +15,11 @@ console = Console()
 
 async def _get_memory_count(assistant_id: str) -> int:
     """Get the number of memories stored for an assistant."""
-    from tribalmind.backboard.client import create_client
-    from tribalmind.backboard.memory import list_memories
+    from tribalmind.providers import get_provider
 
-    async with create_client() as client:
-        memories = await list_memories(client, assistant_id)
+    provider = get_provider()
+    async with provider:
+        memories = await provider.list_all()
         return len(memories)
 
 
@@ -36,7 +36,6 @@ def status(
         tribal status
         tribal status --json
     """
-    from tribalmind.backboard.client import BackboardError
     from tribalmind.config.settings import get_settings
 
     settings = get_settings()
@@ -47,11 +46,12 @@ def status(
     if configured:
         try:
             memory_count = asyncio.run(_get_memory_count(assistant_id))
-        except BackboardError:
+        except Exception:
             memory_count = -1  # indicate error
 
     info = {
         "configured": configured,
+        "provider": settings.provider,
         "project_root": str(settings.project_root),
         "assistant_id": assistant_id or "",
         "memory_count": memory_count,
@@ -69,6 +69,8 @@ def status(
         return
 
     lines = Text()
+    lines.append("Provider:   ", style="dim")
+    lines.append(f"{settings.provider}\n", style="#a78bfa")
     lines.append("Project:    ", style="dim")
     lines.append(str(settings.project_root) + "\n")
     lines.append("Assistant:  ", style="dim")

--- a/lib/tribalmind/config/settings.py
+++ b/lib/tribalmind/config/settings.py
@@ -112,9 +112,17 @@ class TribalSettings(BaseSettings):
         extra="ignore",
     )
 
+    # Memory provider (backboard, mem0, etc.)
+    provider: str = "backboard"
+
     # Backboard
     backboard_base_url: str = "https://app.backboard.io/api"
     backboard_api_key: str = ""
+
+    # Mem0 (optional — only needed when provider=mem0)
+    mem0_api_key: str = ""
+    mem0_org_id: str = ""
+    mem0_project_id: str = ""
 
     # Project
     project_root: Path = Field(default_factory=Path.cwd)

--- a/lib/tribalmind/providers/__init__.py
+++ b/lib/tribalmind/providers/__init__.py
@@ -1,0 +1,9 @@
+"""Pluggable memory provider abstraction.
+
+Providers implement the MemoryProvider protocol and are registered in the factory.
+"""
+
+from tribalmind.providers.base import MemoryProvider
+from tribalmind.providers.factory import get_provider, get_provider_choices
+
+__all__ = ["MemoryProvider", "get_provider", "get_provider_choices"]

--- a/lib/tribalmind/providers/backboard_provider.py
+++ b/lib/tribalmind/providers/backboard_provider.py
@@ -1,0 +1,87 @@
+"""Backboard memory provider — wraps the existing Backboard API client.
+
+This is the default provider and preserves 100% backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tribalmind.backboard.client import BackboardClient, create_client
+from tribalmind.backboard.memory import (
+    MemoryEntry,
+    add_memory,
+    clear_memories,
+    delete_memory,
+    enforce_memory_limit,
+    list_memories,
+    search_memories,
+    update_memory,
+)
+
+
+class BackboardProvider:
+    """Memory provider backed by the Backboard API."""
+
+    def __init__(self, client: BackboardClient | None = None, assistant_id: str = ""):
+        self._client = client
+        self._owns_client = client is None
+        self._assistant_id = assistant_id
+
+    def _get_assistant_id(self) -> str:
+        if self._assistant_id:
+            return self._assistant_id
+        from tribalmind.config.settings import get_settings
+
+        settings = get_settings()
+        aid = settings.project_assistant_id
+        if not aid:
+            raise RuntimeError(
+                "No project assistant configured. Run 'tribal init' first."
+            )
+        return aid
+
+    async def _ensure_client(self) -> BackboardClient:
+        if self._client is None:
+            self._client = create_client()
+        return self._client
+
+    async def add(self, content: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        client = await self._ensure_client()
+        return await add_memory(client, self._get_assistant_id(), content, metadata=metadata)
+
+    async def search(self, query: str, limit: int = 10) -> list[MemoryEntry]:
+        client = await self._ensure_client()
+        return await search_memories(client, self._get_assistant_id(), query, limit=limit)
+
+    async def list_all(self) -> list[MemoryEntry]:
+        client = await self._ensure_client()
+        return await list_memories(client, self._get_assistant_id())
+
+    async def delete(self, memory_id: str) -> None:
+        client = await self._ensure_client()
+        await delete_memory(client, self._get_assistant_id(), memory_id)
+
+    async def update(self, memory_id: str, content: str) -> dict[str, Any]:
+        client = await self._ensure_client()
+        return await update_memory(client, self._get_assistant_id(), memory_id, content)
+
+    async def clear(self) -> int:
+        client = await self._ensure_client()
+        return await clear_memories(client, self._get_assistant_id())
+
+    async def enforce_limit(self, max_memories: int) -> int:
+        client = await self._ensure_client()
+        return await enforce_memory_limit(client, self._get_assistant_id(), max_memories)
+
+    async def close(self) -> None:
+        if self._client and self._owns_client:
+            await self._client.close()
+            self._client = None
+
+    async def __aenter__(self) -> BackboardProvider:
+        await self._ensure_client()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()

--- a/lib/tribalmind/providers/base.py
+++ b/lib/tribalmind/providers/base.py
@@ -1,0 +1,55 @@
+"""MemoryProvider protocol — the minimal interface all providers must implement."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from tribalmind.backboard.memory import MemoryEntry
+
+
+@runtime_checkable
+class MemoryProvider(Protocol):
+    """Async interface for memory storage backends.
+
+    All providers must implement these methods. The MemoryEntry dataclass
+    and JSON schema (category/subject/content) are TribalMind's layer,
+    independent of the underlying storage.
+    """
+
+    async def add(self, content: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Store a memory. Returns the raw provider response."""
+        ...
+
+    async def search(self, query: str, limit: int = 10) -> list[MemoryEntry]:
+        """Search memories by semantic similarity."""
+        ...
+
+    async def list_all(self) -> list[MemoryEntry]:
+        """List all stored memories."""
+        ...
+
+    async def delete(self, memory_id: str) -> None:
+        """Delete a single memory by ID."""
+        ...
+
+    async def update(self, memory_id: str, content: str) -> dict[str, Any]:
+        """Update a memory's content. Returns the raw provider response."""
+        ...
+
+    async def clear(self) -> int:
+        """Delete ALL memories. Returns the count deleted."""
+        ...
+
+    async def enforce_limit(self, max_memories: int) -> int:
+        """Prune oldest memories if count exceeds max_memories. Returns count pruned."""
+        ...
+
+    async def close(self) -> None:
+        """Release any resources held by the provider."""
+        ...
+
+    async def __aenter__(self) -> MemoryProvider:
+        ...
+
+    async def __aexit__(self, *args: Any) -> None:
+        ...

--- a/lib/tribalmind/providers/factory.py
+++ b/lib/tribalmind/providers/factory.py
@@ -1,0 +1,111 @@
+"""Provider factory — resolves a provider name to a configured instance.
+
+New providers are registered by adding an entry to _REGISTRY.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tribalmind.providers.base import MemoryProvider
+
+# Registry: name -> (label, builder_function, coming_soon)
+# builder_function receives TribalSettings and returns a MemoryProvider
+_REGISTRY: dict[str, tuple[str, Any, bool]] = {}
+
+
+def _register_builtin_providers() -> None:
+    """Register the built-in providers."""
+
+    def _build_backboard(settings) -> MemoryProvider:
+        from tribalmind.providers.backboard_provider import BackboardProvider
+
+        return BackboardProvider(assistant_id=settings.project_assistant_id or "")
+
+    def _build_mem0(settings) -> MemoryProvider:
+        from tribalmind.providers.mem0_provider import Mem0Provider
+
+        api_key = settings.mem0_api_key
+        if not api_key:
+            raise ValueError(
+                "Mem0 API key not configured. "
+                "Set it via 'tribal init' or TRIBAL_MEM0_API_KEY environment variable."
+            )
+
+        # Mem0 SDK requires both org_id and project_id, or neither.
+        org_id = settings.mem0_org_id or None
+        project_id = settings.mem0_project_id or None
+        if bool(org_id) != bool(project_id):
+            raise ValueError(
+                "Mem0 requires both org_id and project_id, or neither. "
+                "Set both via 'tribal init' or TRIBAL_MEM0_ORG_ID / TRIBAL_MEM0_PROJECT_ID."
+            )
+
+        return Mem0Provider(
+            api_key=api_key,
+            org_id=org_id,
+            project_id=project_id,
+            user_id=settings.project_assistant_id or "tribalmind",
+        )
+
+    _REGISTRY["backboard"] = ("Backboard (default — hosted, team-shared)", _build_backboard, False)
+    _REGISTRY["mem0"] = ("Mem0 (graph memory, managed)", _build_mem0, False)
+
+
+# Initialize on import
+_register_builtin_providers()
+
+
+def get_provider_choices() -> list[tuple[str, str, bool]]:
+    """Return list of (label, name, coming_soon) for provider selection UI."""
+    return [
+        (label, name, coming_soon)
+        for name, (label, _, coming_soon) in _REGISTRY.items()
+    ]
+
+
+def get_provider(provider_name: str | None = None) -> MemoryProvider:
+    """Create and return a configured MemoryProvider instance.
+
+    If provider_name is None, reads from settings (which checks env vars and config).
+    Defaults to 'backboard' if nothing is configured.
+    """
+    from tribalmind.config.settings import get_settings
+
+    settings = get_settings()
+
+    if provider_name is None:
+        provider_name = settings.provider
+
+    if provider_name not in _REGISTRY:
+        available = ", ".join(_REGISTRY.keys())
+        raise ValueError(
+            f"Unknown memory provider: {provider_name!r}. "
+            f"Available providers: {available}"
+        )
+
+    _, builder, coming_soon = _REGISTRY[provider_name]
+    if coming_soon:
+        raise ValueError(
+            f"The {provider_name!r} provider is not yet available (coming soon)."
+        )
+
+    return builder(settings)
+
+
+def register_provider(
+    name: str,
+    label: str,
+    builder,
+    *,
+    coming_soon: bool = False,
+) -> None:
+    """Register a custom memory provider.
+
+    Args:
+        name: Short identifier (e.g. 'pinecone')
+        label: Human-readable label for the init prompt
+        builder: Callable that receives TribalSettings and returns a MemoryProvider
+        coming_soon: If True, provider appears in selection but can't be used yet
+    """
+    _REGISTRY[name] = (label, builder, coming_soon)

--- a/lib/tribalmind/providers/mem0_provider.py
+++ b/lib/tribalmind/providers/mem0_provider.py
@@ -1,0 +1,141 @@
+"""Mem0 memory provider — uses the mem0ai SDK for memory storage.
+
+Mem0 offers graph memory and its own extraction pipeline.
+
+Docs: https://docs.mem0.ai/introduction
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mem0 import MemoryClient
+
+from tribalmind.backboard.memory import MemoryEntry, parse_memory
+
+logger = logging.getLogger(__name__)
+
+
+class Mem0Provider:
+    """Memory provider backed by Mem0's managed API.
+
+    Maps TribalMind operations to the Mem0 SDK:
+    - add → client.add(messages, user_id=...)
+    - search → client.search(query, user_id=..., top_k=...)
+    - list_all → client.get_all(user_id=...)
+    - delete → client.delete(memory_id)
+    - update → client.update(memory_id, text=...)
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        org_id: str | None = None,
+        project_id: str | None = None,
+        user_id: str = "tribalmind",
+    ):
+        # org_id and project_id are passed to the constructor;
+        # the SDK attaches them to every request via _prepare_params.
+        self._client = MemoryClient(
+            api_key=api_key,
+            org_id=org_id,
+            project_id=project_id,
+        )
+        self._user_id = user_id
+
+    def _mem0_to_entry(self, item: dict[str, Any]) -> MemoryEntry:
+        """Convert a Mem0 result dict to a MemoryEntry."""
+        # Mem0 stores the memory text in 'memory' field
+        raw_content = item.get("memory", "")
+
+        # Try to parse as our structured JSON format
+        entry = parse_memory(raw_content, raw=item)
+
+        # Override memory_id from Mem0's id field
+        entry.memory_id = item.get("id", "")
+
+        # Mem0 search returns a 'score' field (higher = more relevant)
+        if "score" in item:
+            entry.relevance_score = item["score"]
+
+        return entry
+
+    def _extract_results(self, response: Any) -> list[dict[str, Any]]:
+        """Extract the list of memory items from a Mem0 SDK response."""
+        if isinstance(response, dict):
+            return response.get("results", response.get("memories", []))
+        if isinstance(response, list):
+            return response
+        return []
+
+    async def add(self, content: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"user_id": self._user_id}
+        if metadata:
+            kwargs["metadata"] = metadata
+        result = self._client.add(content, **kwargs)
+        return result if isinstance(result, dict) else {"result": result}
+
+    @property
+    def _user_filters(self) -> dict[str, str]:
+        """Mem0 v2 API requires user_id inside a 'filters' dict for queries."""
+        return {"user_id": self._user_id}
+
+    async def search(self, query: str, limit: int = 10) -> list[MemoryEntry]:
+        results = self._client.search(
+            query, filters=self._user_filters, top_k=limit,
+        )
+        items = self._extract_results(results)
+        return [self._mem0_to_entry(item) for item in items]
+
+    async def list_all(self) -> list[MemoryEntry]:
+        results = self._client.get_all(filters=self._user_filters)
+        items = self._extract_results(results)
+        return [self._mem0_to_entry(item) for item in items]
+
+    async def delete(self, memory_id: str) -> None:
+        self._client.delete(memory_id)
+
+    async def update(self, memory_id: str, content: str) -> dict[str, Any]:
+        # Mem0 SDK uses 'text=' keyword, not positional
+        result = self._client.update(memory_id, text=content)
+        return result if isinstance(result, dict) else {"result": result}
+
+    async def clear(self) -> int:
+        entries = await self.list_all()
+        deleted = 0
+        for entry in entries:
+            if entry.memory_id:
+                await self.delete(entry.memory_id)
+                deleted += 1
+        return deleted
+
+    async def enforce_limit(self, max_memories: int) -> int:
+        if max_memories <= 0:
+            return 0
+
+        entries = await self.list_all()
+        excess = len(entries) - max_memories
+        if excess <= 0:
+            return 0
+
+        # Sort by created_at ascending so oldest come first
+        entries.sort(key=lambda e: e.raw.get("created_at", ""))
+        to_delete = entries[:excess]
+
+        pruned = 0
+        for entry in to_delete:
+            if entry.memory_id:
+                await self.delete(entry.memory_id)
+                pruned += 1
+        return pruned
+
+    async def close(self) -> None:
+        pass
+
+    async def __aenter__(self) -> Mem0Provider:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "questionary>=2.1",
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",
+    "mem0ai>=0.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_cli/test_forget.py
+++ b/tests/unit/test_cli/test_forget.py
@@ -18,48 +18,43 @@ def _extract_json(output: str) -> dict:
     return json.loads(output[start:])
 
 
-class TestForgetCommand:
-    @patch("tribalmind.backboard.memory.delete_memory", new_callable=AsyncMock)
-    @patch("tribalmind.backboard.client.create_client")
-    @patch("tribalmind.config.settings.get_settings")
-    def test_forget_by_id(self, mock_settings, mock_create_client, mock_delete):
-        mock_settings.return_value.project_assistant_id = "ast-123"
+def _mock_provider():
+    """Create a mock provider with async context manager support."""
+    provider = AsyncMock()
+    provider.__aenter__ = AsyncMock(return_value=provider)
+    provider.__aexit__ = AsyncMock(return_value=None)
+    return provider
 
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_create_client.return_value = mock_client
+
+class TestForgetCommand:
+    @patch("tribalmind.cli.forget_cmd.get_provider")
+    @patch("tribalmind.config.settings.get_settings")
+    def test_forget_by_id(self, mock_settings, mock_get_provider):
+        mock_settings.return_value.project_assistant_id = "ast-123"
+        mock_get_provider.return_value = _mock_provider()
 
         result = runner.invoke(app, ["forget", "--id", "mem-001", "--yes"])
         assert result.exit_code == 0
         assert "Deleted" in result.output or "mem-001" in result.output
 
-    @patch("tribalmind.backboard.memory.delete_memory", new_callable=AsyncMock)
-    @patch("tribalmind.backboard.client.create_client")
+    @patch("tribalmind.cli.forget_cmd.get_provider")
     @patch("tribalmind.config.settings.get_settings")
-    def test_forget_by_id_json(self, mock_settings, mock_create_client, mock_delete):
+    def test_forget_by_id_json(self, mock_settings, mock_get_provider):
         mock_settings.return_value.project_assistant_id = "ast-123"
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_create_client.return_value = mock_client
+        mock_get_provider.return_value = _mock_provider()
 
         result = runner.invoke(app, ["forget", "--id", "mem-001", "--json"])
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert data["deleted"] == ["mem-001"]
 
-    @patch("tribalmind.backboard.memory.clear_memories", new_callable=AsyncMock, return_value=5)
-    @patch("tribalmind.backboard.client.create_client")
+    @patch("tribalmind.cli.forget_cmd.get_provider")
     @patch("tribalmind.config.settings.get_settings")
-    def test_forget_all_with_yes(self, mock_settings, mock_create_client, mock_clear):
+    def test_forget_all_with_yes(self, mock_settings, mock_get_provider):
         mock_settings.return_value.project_assistant_id = "ast-123"
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_create_client.return_value = mock_client
+        provider = _mock_provider()
+        provider.clear.return_value = 5
+        mock_get_provider.return_value = provider
 
         result = runner.invoke(app, ["forget", "--all", "--yes"])
         assert result.exit_code == 0
@@ -77,23 +72,15 @@ class TestForgetCommand:
         result = runner.invoke(app, ["forget"])
         assert result.exit_code == 1
 
-    @patch("tribalmind.backboard.memory.delete_memory", new_callable=AsyncMock)
-    @patch("tribalmind.backboard.memory.search_memories", new_callable=AsyncMock)
-    @patch("tribalmind.backboard.client.create_client")
+    @patch("tribalmind.cli.forget_cmd.get_provider")
     @patch("tribalmind.config.settings.get_settings")
-    def test_forget_by_query_with_yes(
-        self, mock_settings, mock_create_client, mock_search, mock_delete,
-    ):
+    def test_forget_by_query_with_yes(self, mock_settings, mock_get_provider):
         mock_settings.return_value.project_assistant_id = "ast-123"
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_create_client.return_value = mock_client
-
-        mock_search.return_value = [
+        provider = _mock_provider()
+        provider.search.return_value = [
             MemoryEntry(raw_content="test", memory_id="mem-001", category="fix", content="do X"),
         ]
+        mock_get_provider.return_value = provider
 
         result = runner.invoke(app, ["forget", "--yes", "old", "redis", "fix"])
         assert result.exit_code == 0

--- a/tests/unit/test_cli/test_init.py
+++ b/tests/unit/test_cli/test_init.py
@@ -14,12 +14,16 @@ class TestInitCommand:
     @patch("tribalmind.cli.init_cmd._setup_assistant", new_callable=AsyncMock)
     @patch("tribalmind.cli.init_cmd._find_git_root")
     @patch("tribalmind.config.credentials.get_backboard_api_key", return_value="test-key-12345678")
-    def test_init_with_existing_key(self, mock_get_key, mock_git_root, mock_setup, tmp_path):
+    def test_init_with_existing_key(
+        self, mock_get_key, mock_git_root, mock_setup, tmp_path, monkeypatch,
+    ):
         mock_git_root.return_value = tmp_path
         mock_setup.return_value = {"assistant_id": "ast-123"}
+        monkeypatch.chdir(tmp_path)
 
-        # "1" = LLM selection, "n" = agent integration, "n" = shell completions
-        result = runner.invoke(app, ["init"], input="1\nn\nn\n")
+        # "1" = provider (Backboard), "1" = LLM selection,
+        # "n" = agent integration, "n" = shell completions
+        result = runner.invoke(app, ["init"], input="1\n1\nn\nn\n")
         assert result.exit_code == 0
         assert "initialized" in result.output.lower() or "ast-123" in result.output
         mock_setup.assert_called_once()
@@ -29,10 +33,11 @@ class TestInitCommand:
     @patch("tribalmind.config.credentials.get_backboard_api_key", return_value=None)
     @patch("tribalmind.config.credentials.set_credential")
     def test_init_with_api_key_flag(
-        self, mock_set, mock_get_key, mock_git_root, mock_setup, tmp_path,
+        self, mock_set, mock_get_key, mock_git_root, mock_setup, tmp_path, monkeypatch,
     ):
         mock_git_root.return_value = tmp_path
         mock_setup.return_value = {"assistant_id": "ast-456"}
+        monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["init", "--api-key", "sk-test1234567890"])
         assert result.exit_code == 0
@@ -40,10 +45,14 @@ class TestInitCommand:
         mock_set.assert_called_once()
 
     @patch("tribalmind.cli.init_cmd._setup_assistant", new_callable=AsyncMock)
+    @patch("tribalmind.cli.init_cmd._find_git_root")
     @patch("tribalmind.config.credentials.set_credential")
-    def test_init_api_error(self, mock_set, mock_setup):
+    def test_init_api_error(self, mock_set, mock_git_root, mock_setup, tmp_path, monkeypatch):
         from tribalmind.backboard.client import BackboardError
+
+        mock_git_root.return_value = tmp_path
         mock_setup.side_effect = BackboardError(401, "Invalid API key")
+        monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["init", "--api-key", "sk-bad-key-test"])
         assert result.exit_code == 1
@@ -56,15 +65,41 @@ class TestInitCommand:
     @patch("tribalmind.config.credentials.set_credential")
     def test_init_prompts_for_key(
         self, mock_set, mock_get_key, mock_client_cls, mock_git_root,
-        mock_setup, tmp_path,
+        mock_setup, tmp_path, monkeypatch,
     ):
         mock_git_root.return_value = tmp_path
         mock_setup.return_value = {"assistant_id": "ast-789"}
+        monkeypatch.chdir(tmp_path)
         # Make the validation client a no-op async context manager
         client_instance = AsyncMock()
         mock_client_cls.return_value = client_instance
 
-        # API key, "1" = LLM selection, "n" = agent integration, "n" = completions
-        result = runner.invoke(app, ["init"], input="my-secret-api-key-1234\n1\nn\nn\n")
+        # "1" = provider (Backboard), API key, "1" = LLM selection,
+        # "n" = agent integration, "n" = completions
+        result = runner.invoke(
+            app, ["init"], input="1\nmy-secret-api-key-1234\n1\nn\nn\n"
+        )
         assert result.exit_code == 0
         mock_set.assert_called_once()
+
+    @patch("tribalmind.cli.init_cmd._setup_assistant", new_callable=AsyncMock)
+    @patch("tribalmind.cli.init_cmd._find_git_root")
+    @patch("tribalmind.config.credentials.get_backboard_api_key", return_value="test-key-12345678")
+    @patch("tribalmind.config.credentials.set_credential")
+    def test_init_with_provider_flag(
+        self, mock_set, mock_get_key, mock_git_root, mock_setup, tmp_path, monkeypatch,
+    ):
+        mock_git_root.return_value = tmp_path
+        mock_setup.return_value = {"assistant_id": "ast-123"}
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(
+            app, ["init", "--provider", "backboard", "--api-key", "sk-test1234567890"]
+        )
+        assert result.exit_code == 0
+        assert "backboard" in result.output.lower()
+
+    def test_init_with_invalid_provider_flag(self):
+        result = runner.invoke(app, ["init", "--provider", "nonexistent"])
+        assert result.exit_code == 1
+        assert "Unknown provider" in result.output

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -23,6 +23,7 @@ class TestStatusCommand:
     def test_status_configured(self, mock_settings, mock_count):
         mock_settings.return_value.project_assistant_id = "ast-123"
         mock_settings.return_value.project_root = "/my/project"
+        mock_settings.return_value.provider = "backboard"
         mock_settings.return_value.llm_provider = "anthropic"
         mock_settings.return_value.model_name = "claude-sonnet-4-20250514"
         mock_count.return_value = 42
@@ -36,6 +37,7 @@ class TestStatusCommand:
     def test_status_not_configured(self, mock_settings):
         mock_settings.return_value.project_assistant_id = None
         mock_settings.return_value.project_root = "/my/project"
+        mock_settings.return_value.provider = "backboard"
         mock_settings.return_value.llm_provider = "anthropic"
         mock_settings.return_value.model_name = "claude-sonnet-4-20250514"
 
@@ -48,6 +50,7 @@ class TestStatusCommand:
     def test_status_json(self, mock_settings, mock_count):
         mock_settings.return_value.project_assistant_id = "ast-123"
         mock_settings.return_value.project_root = "/my/project"
+        mock_settings.return_value.provider = "backboard"
         mock_settings.return_value.llm_provider = "anthropic"
         mock_settings.return_value.model_name = "claude-sonnet-4-20250514"
         mock_count.return_value = 10
@@ -58,3 +61,4 @@ class TestStatusCommand:
         assert data["configured"] is True
         assert data["memory_count"] == 10
         assert data["assistant_id"] == "ast-123"
+        assert data["provider"] == "backboard"

--- a/tests/unit/test_providers/test_backboard_provider.py
+++ b/tests/unit/test_providers/test_backboard_provider.py
@@ -1,0 +1,153 @@
+"""Tests for BackboardProvider."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from tribalmind.backboard.memory import MemoryEntry
+from tribalmind.providers.backboard_provider import BackboardProvider
+
+
+@pytest.fixture
+def mock_client():
+    client = AsyncMock()
+    client.post = AsyncMock(return_value={})
+    client.get = AsyncMock(return_value=[])
+    client.put = AsyncMock(return_value={})
+    client.delete = AsyncMock(return_value={})
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def provider(mock_client):
+    return BackboardProvider(client=mock_client, assistant_id="test-assistant-123")
+
+
+class TestBackboardProviderAdd:
+    async def test_add_calls_backboard(self, provider, mock_client):
+        content = json.dumps({"category": "fix", "subject": "test", "content": "test content"})
+        await provider.add(content)
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert "test-assistant-123" in call_args[0][0]
+        assert "memories" in call_args[0][0]
+
+    async def test_add_with_metadata(self, provider, mock_client):
+        metadata = {"category": "fix", "subject": "test"}
+        await provider.add("content", metadata=metadata)
+        call_kwargs = mock_client.post.call_args[1]
+        assert call_kwargs["json"]["metadata"] == metadata
+
+
+class TestBackboardProviderSearch:
+    async def test_search_returns_memory_entries(self, provider, mock_client):
+        mock_client.post.return_value = [
+            {
+                "id": "mem-1",
+                "content": json.dumps({
+                    "category": "fix",
+                    "subject": "test",
+                    "content": "test content",
+                }),
+                "score": 0.1,
+            }
+        ]
+        results = await provider.search("test query")
+        assert len(results) == 1
+        assert isinstance(results[0], MemoryEntry)
+        assert results[0].category == "fix"
+
+    async def test_search_with_limit(self, provider, mock_client):
+        mock_client.post.return_value = []
+        await provider.search("test", limit=5)
+        call_kwargs = mock_client.post.call_args[1]
+        assert call_kwargs["json"]["limit"] == 5
+
+
+class TestBackboardProviderListAll:
+    async def test_list_all_returns_entries(self, provider, mock_client):
+        mock_client.get.return_value = [
+            {
+                "id": "mem-1",
+                "content": json.dumps({
+                    "category": "tip",
+                    "subject": "debug",
+                    "content": "use verbose",
+                }),
+            }
+        ]
+        results = await provider.list_all()
+        assert len(results) == 1
+        assert results[0].category == "tip"
+
+
+class TestBackboardProviderDelete:
+    async def test_delete_calls_backboard(self, provider, mock_client):
+        await provider.delete("mem-123")
+        mock_client.delete.assert_called_once()
+        assert "mem-123" in mock_client.delete.call_args[0][0]
+
+
+class TestBackboardProviderUpdate:
+    async def test_update_calls_backboard(self, provider, mock_client):
+        await provider.update("mem-123", "new content")
+        mock_client.put.assert_called_once()
+        assert "mem-123" in mock_client.put.call_args[0][0]
+
+
+class TestBackboardProviderClear:
+    async def test_clear_deletes_all(self, provider, mock_client):
+        mock_client.get.return_value = [
+            {"id": "mem-1", "content": "{}"},
+            {"id": "mem-2", "content": "{}"},
+        ]
+        count = await provider.clear()
+        assert count == 2
+        assert mock_client.delete.call_count == 2
+
+
+class TestBackboardProviderEnforceLimit:
+    async def test_enforce_limit_prunes_excess(self, provider, mock_client):
+        mock_client.get.return_value = [
+            {"id": f"mem-{i}", "content": "{}", "created_at": f"2024-01-0{i}"}
+            for i in range(1, 6)
+        ]
+        pruned = await provider.enforce_limit(3)
+        assert pruned == 2
+        assert mock_client.delete.call_count == 2
+
+    async def test_enforce_limit_no_op_when_under(self, provider, mock_client):
+        mock_client.get.return_value = [
+            {"id": "mem-1", "content": "{}"},
+        ]
+        pruned = await provider.enforce_limit(10)
+        assert pruned == 0
+        mock_client.delete.assert_not_called()
+
+
+class TestBackboardProviderContextManager:
+    async def test_context_manager(self, mock_client):
+        provider = BackboardProvider(client=mock_client, assistant_id="test")
+        async with provider:
+            pass
+        # Client was passed in, so provider doesn't own it — shouldn't close
+        mock_client.close.assert_not_called()
+
+    async def test_context_manager_owns_client(self, monkeypatch):
+        """When no client is passed, provider creates and closes its own."""
+        mock_client = AsyncMock()
+
+        def mock_create():
+            return mock_client
+
+        monkeypatch.setattr(
+            "tribalmind.providers.backboard_provider.create_client",
+            mock_create,
+        )
+        provider = BackboardProvider(assistant_id="test")
+        async with provider:
+            pass
+        mock_client.close.assert_called_once()

--- a/tests/unit/test_providers/test_base.py
+++ b/tests/unit/test_providers/test_base.py
@@ -1,0 +1,18 @@
+"""Tests for the MemoryProvider protocol."""
+
+from __future__ import annotations
+
+from tribalmind.providers.backboard_provider import BackboardProvider
+from tribalmind.providers.base import MemoryProvider
+
+
+class TestMemoryProviderProtocol:
+    def test_backboard_provider_implements_protocol(self):
+        """BackboardProvider must satisfy the MemoryProvider protocol."""
+        assert isinstance(BackboardProvider(), MemoryProvider)
+
+    def test_protocol_is_runtime_checkable(self):
+        """Protocol should be runtime-checkable for isinstance()."""
+        assert hasattr(MemoryProvider, "__protocol_attrs__") or hasattr(
+            MemoryProvider, "__abstractmethods__"
+        ) or issubclass(type(MemoryProvider), type)

--- a/tests/unit/test_providers/test_factory.py
+++ b/tests/unit/test_providers/test_factory.py
@@ -1,0 +1,89 @@
+"""Tests for the provider factory."""
+
+from __future__ import annotations
+
+import pytest
+from tribalmind.providers.backboard_provider import BackboardProvider
+from tribalmind.providers.factory import (
+    _REGISTRY,
+    get_provider,
+    get_provider_choices,
+    register_provider,
+)
+
+
+class TestGetProviderChoices:
+    def test_returns_backboard_and_mem0(self):
+        choices = get_provider_choices()
+        names = [name for _, name, _ in choices]
+        assert "backboard" in names
+        assert "mem0" in names
+
+    def test_backboard_is_first(self):
+        choices = get_provider_choices()
+        assert choices[0][1] == "backboard"
+
+    def test_returns_tuples(self):
+        choices = get_provider_choices()
+        for label, name, coming_soon in choices:
+            assert isinstance(label, str)
+            assert isinstance(name, str)
+            assert isinstance(coming_soon, bool)
+
+
+class TestGetProvider:
+    def test_backboard_default(self, settings):
+        provider = get_provider("backboard")
+        assert isinstance(provider, BackboardProvider)
+
+    def test_unknown_provider_raises(self, settings):
+        with pytest.raises(ValueError, match="Unknown memory provider"):
+            get_provider("nonexistent")
+
+    def test_defaults_to_settings_provider(self, monkeypatch, settings):
+        monkeypatch.setenv("TRIBAL_PROVIDER", "backboard")
+        provider = get_provider()
+        assert isinstance(provider, BackboardProvider)
+
+    def test_mem0_without_api_key_raises(self, monkeypatch, tmp_path):
+        # Ensure clean settings with no mem0 config from YAML
+        monkeypatch.setenv("TRIBAL_BACKBOARD_API_KEY", "test-key")
+        monkeypatch.setenv("TRIBAL_PROJECT_ROOT", str(tmp_path))
+        monkeypatch.setenv("TRIBAL_PROJECT_ASSISTANT_ID", "test-123")
+        monkeypatch.delenv("TRIBAL_MEM0_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)  # avoid picking up .tribal/config.yaml
+
+        from tribalmind.config.settings import clear_settings_cache
+        clear_settings_cache()
+
+        with pytest.raises(ValueError, match="Mem0 API key not configured"):
+            get_provider("mem0")
+
+
+class TestRegisterProvider:
+    def test_register_custom_provider(self):
+        def build(settings):
+            return BackboardProvider()
+
+        register_provider("custom-test", "Custom Test Provider", build)
+        assert "custom-test" in _REGISTRY
+
+        choices = get_provider_choices()
+        names = [name for _, name, _ in choices]
+        assert "custom-test" in names
+
+        # Clean up
+        del _REGISTRY["custom-test"]
+
+    def test_register_coming_soon(self):
+        def build(settings):
+            raise NotImplementedError
+
+        register_provider("future-test", "Future Provider", build, coming_soon=True)
+        assert _REGISTRY["future-test"][2] is True
+
+        with pytest.raises(ValueError, match="not yet available"):
+            get_provider("future-test")
+
+        # Clean up
+        del _REGISTRY["future-test"]


### PR DESCRIPTION
## Summary

- Introduces a **provider abstraction layer** so users can choose their memory backend during `tribal init` — Backboard (default) or Mem0, with a registry pattern for adding more
- **Mem0 provider** passes raw text directly to Mem0's own extraction/categorization pipeline (no redundant LLM parsing step)
- All CLI commands (`remember`, `recall`, `forget`, `status`, `config`) now use `get_provider()` instead of direct Backboard client calls
- `mem0ai` is a **core dependency** so users can select it during init without a separate install step
- Custom providers can be registered via `register_provider(name, label, builder)`

### Key files
- `lib/tribalmind/providers/` — new package: `base.py` (Protocol), `factory.py` (registry), `backboard_provider.py`, `mem0_provider.py`
- `lib/tribalmind/cli/init_cmd.py` — provider selection step + per-provider credential prompts
- `lib/tribalmind/cli/remember_cmd.py` — skip LLM parsing for non-Backboard providers
- `lib/tribalmind/config/settings.py` — `provider`, `mem0_api_key`, `mem0_org_id`, `mem0_project_id` fields

Closes #39

## Test plan

- [x] All 93 existing tests pass
- [x] New provider tests: protocol conformance, factory, BackboardProvider unit tests
- [x] `tribal remember` works end-to-end with Mem0 provider (verified against live API)
- [x] `tribal recall` works end-to-end with Mem0 provider
- [x] Graceful fallback when Backboard API key is missing (no crash, no noisy errors)
- [x] Test isolation fixed: init tests no longer pollute real config or system keyring
- [ ] Test `tribal init` interactive flow selecting Mem0
- [ ] Test `tribal init --provider mem0` non-interactive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)